### PR TITLE
Fix for React Native 62.2

### DIFF
--- a/src/ElementContainer.js
+++ b/src/ElementContainer.js
@@ -233,7 +233,7 @@ export class ElementContainer extends PureComponent {
     async _measureSelected() {
         let parentMeasurement = await new Promise((resolve, reject) => {
             try {
-                this._parent._component.measureInWindow((winX, winY, winWidth, winHeight) => {
+                this._parent.measureInWindow((winX, winY, winWidth, winHeight) => {
                     resolve({
                         x: winX,
                         y: winY,


### PR DESCRIPTION
MeasureInWindow should now be called on the parent not the component.
https://stackoverflow.com/questions/60944091/taskqueue-error-with-task-undefined-is-not-an-object-evaluating-this-view